### PR TITLE
Use process.cwd() instead of __dirname for DLL loading to be compatible with zeit/pkg

### DIFF
--- a/index.js
+++ b/index.js
@@ -1341,7 +1341,7 @@ var dll = get_dll();
 if(dll === null)
     throw new Error('autoit can not run on this platform!');
 
-var autoit_dll = ffi.Library(path.join(__dirname, dll), autoit_functions);
+var autoit_dll = ffi.Library(path.join(process.cwd(), dll), autoit_functions);
 
 function modify_func(func){
     var old_func = autoit_dll[func];


### PR DESCRIPTION
In order to be compatible with https://github.com/zeit/pkg which is an amazing packaging tool for node.js projects, a simple modification has to be done in this package.

Indeed, if a file is requested using a relative path to `__dirname` it will be automatically packaged into the resulting executable (https://github.com/zeit/pkg#detecting-assets-in-source-code). This is useful for most of the cases, but here since the DLL is loaded using Windows functions, it does not have access to the snapshot file system.